### PR TITLE
Fix missing positions

### DIFF
--- a/entsoe_client/Parsers/ParserUtils.py
+++ b/entsoe_client/Parsers/ParserUtils.py
@@ -80,14 +80,14 @@ def Period_to_DataFrame_fn(get_Period_data: Callable) -> Callable:
         # Get the timestamp index
         index_df = get_Period_index(Period).to_frame(name="index", index=False)
         index_df.index += 1
+        index_df.index = index_df.index.astype(str)
 
         # extract the data with the position
         data = get_Period_data(Period)
         data_df = pd.DataFrame(data=data).set_index("position")
-        data_df.index = data_df.index.astype(int)
 
         # Join these to have the full data
-        df = index_df.join(data_df)
+        df = index_df.join(data_df).reset_index(names="position").set_index("index")
 
         metadata_nodes: list = Period.xpath(
             f"./*[not(self::Point)]", namespaces=Period.nsmap

--- a/entsoe_client/Parsers/ParserUtils.py
+++ b/entsoe_client/Parsers/ParserUtils.py
@@ -77,10 +77,17 @@ def Period_to_DataFrame_fn(get_Period_data: Callable) -> Callable:
         Periods are implicitly valid as index is constructed independent from data extraction.
         Errors would occur at DataFrame construction.
         """
-        index = get_Period_index(Period)
-        data = get_Period_data(Period, length=len(index))
-        assert len(data) == len(index)
-        df = pd.DataFrame(data=data, index=index)
+        # Get the timestamp index
+        index_df = get_Period_index(Period).to_frame(name="index", index=False)
+        index_df.index += 1
+
+        # extract the data with the position
+        data = get_Period_data(Period)
+        data_df = pd.DataFrame(data=data).set_index("position")
+        data_df.index = data_df.index.astype(int)
+
+        # Join these to have the full data
+        df = index_df.join(data_df)
 
         metadata_nodes: list = Period.xpath(
             f"./*[not(self::Point)]", namespaces=Period.nsmap


### PR DESCRIPTION
If positions are just “missing” the lengths aren't the same. This is needless, as we still know how to create a data frame out of this. 

I suggest exactly that.

To reproduce:
```
response = client(DayAheadPrices(
    in_Domain=Area("DE_LU"),
    periodStart=pd.to_datetime(datetime(2023, 2, 12).astimezone(tz)).tz_convert("UTC"),
    periodEnd=pd.to_datetime(datetime(2023, 2, 13).astimezone(tz)).tz_convert("UTC")
))
```
this will have missing positions.